### PR TITLE
fix(watcher): close GRPC connection with cosmos hub when done

### DIFF
--- a/rpcwatcher/watcher.go
+++ b/rpcwatcher/watcher.go
@@ -445,7 +445,9 @@ func HandleCosmosHubBlock(w *Watcher, data coretypes.ResultEvent) {
 	}
 
 	defer func() {
-		grpcConn.Close()
+		if err := grpcConn.Close(); err != nil {
+			w.l.Errorw("cannot close gRPC client", "error", err, "chain_name", w.Name)
+		}
 	}()
 
 	liquidityQuery := liquiditytypes.NewQueryClient(grpcConn)


### PR DESCRIPTION
This commit closes the GRPC connection in a defer statement, so that all
code paths will execute that.