### PR TITLE
fix: container name copy-paste typo

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       containers:
-        - name: api-server
+        - name: rpcwatcher
           image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:


### PR DESCRIPTION
It was driving me insane cause I was making some charts in grafana grouping by container name and I was seeing weird results :) 